### PR TITLE
updates readme to point to gitlab project

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Then, change the rpi4 system dependency to `{:kiosk_system_rpi4, "~> 0.1.0"}
 ## Running the Kiosk
 
 The kiosk works by starting a
-[weston](https://github.com/wayland-project/weston) instance and then launching
+[weston](https://gitlab.freedesktop.org/wayland/weston) instance and then launching
 a [cog](https://github.com/Igalia/cog) browser inside weston at a designated
 url. Roughly it looks like this:
 


### PR DESCRIPTION
👋 
I was checking out your project as I am looking to start working on another kiosk application in Nerves and looking for an
alternative to using Scenic.
I noticed that the Url for the Wayland/Weston project does not go to an active project on Github.
It gives a 404.
The organization does not have any public repos on Github.
This could be a recent change.
![Screenshot 2023-03-27 at 9 52 22 AM](https://user-images.githubusercontent.com/1010618/227977380-c5f0710f-ae39-45be-b822-94f9790fc39f.png)
I did a little search and found the public repo on Gitlab.
I hope this is helpful and I am looking forward to testing out this kiosk system on my next project.
